### PR TITLE
Adding Helpers for Tournament

### DIFF
--- a/academy_tutorial/tournament/server.py
+++ b/academy_tutorial/tournament/server.py
@@ -4,14 +4,15 @@ import argparse
 import asyncio
 import logging
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from academy.exchange import HttpExchangeFactory
+from academy.exchange.cloud.client import HttpAgentRegistration
 from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.logging import init_logging
 from academy.manager import Manager
+from academy.runtime import RuntimeConfig
 from aiohttp import web
 
 from academy_tutorial.tournament.agent import TournamentAgent
@@ -92,18 +93,32 @@ def init_func(argv: str | None) -> web.Application:
     return asyncio.run(create_app(agent, args.exchange, auth_method))
 
 
-async def main() -> None:
+async def main(agent_id: str | None) -> None:
     """Launches the tournament agent and backend server."""
     init_logging(logging.INFO)
+
     factory = HttpExchangeFactory(
         'https://exchange.academy-agents.org',
         auth_method='globus',
     )
+
+    registration: HttpAgentRegistration[Any] | None = None
+    if agent_id is not None:
+        agent_id = AgentId(uid=uuid.UUID(agent_id))
+        registration = HttpAgentRegistration(
+            agent_id=agent_id,
+        )
     async with await Manager.from_exchange_factory(
         factory=factory,
-        executors=ThreadPoolExecutor(),
     ) as manager:
-        tournament = await manager.launch(TournamentAgent)
+        tournament = await manager.launch(
+            TournamentAgent,
+            config=RuntimeConfig(
+                terminate_on_success=False,
+                terminate_on_error=False,
+            ),
+            registration=registration,
+        )
         console = await factory.console()
         await console.share_mailbox(
             tournament.agent_id,
@@ -115,6 +130,8 @@ async def main() -> None:
         runner = web.AppRunner(app)
         await runner.setup()
         site = web.TCPSite(runner, '0.0.0.0', 9123)
+
+        print('Starting app!')
         await site.start()
 
         while True:
@@ -122,4 +139,15 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    raise SystemExit(asyncio.run(main()))
+    parser = argparse.ArgumentParser(
+        description='Start the battlehsip tournament agent',
+    )
+    parser.add_argument(
+        '--agent_id',
+        '-a',
+        type=str,
+        help='ID of Agent if mailbox has been registered before.',
+    )
+    args = parser.parse_args()
+
+    raise SystemExit(asyncio.run(main(args.agent_id)))

--- a/academy_tutorial/tournament/server.py
+++ b/academy_tutorial/tournament/server.py
@@ -104,6 +104,11 @@ async def main() -> None:
         executors=ThreadPoolExecutor(),
     ) as manager:
         tournament = await manager.launch(TournamentAgent)
+        console = await factory.console()
+        await console.share_mailbox(
+            tournament.agent_id,
+            uuid.UUID('47697db5-c19f-11f0-981f-0ee9d7d7fffb'),
+        )
         print(f'Tournament Agent Id: {tournament.agent_id.uid}')
 
         app = await create_app(tournament.agent_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "academy-py>=0.3.0",
+    "academy-py @ git+https://github.com/academy-agents/academy.git@yadu/add_groups_support_to_mailboxes",
     "emoji",
     "globus-compute-sdk"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
 ]
 description = "Materials for academy tutorial"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 classifiers = [
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "academy-py @ git+https://github.com/academy-agents/academy.git@yadu/add_groups_support_to_mailboxes",
+    "academy-py>=0.4.0",
     "emoji",
     "globus-compute-sdk"
 ]

--- a/solutions/05-battleship/enter_tournament.py
+++ b/solutions/05-battleship/enter_tournament.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Literal
+
+from academy.agent import action
+from academy.exchange.cloud import HttpExchangeFactory
+from academy.handle import Handle
+from academy.identifier import AgentId
+from academy.logging import init_logging
+from academy.manager import Manager
+
+from academy_tutorial.battleship import Board
+from academy_tutorial.battleship import Crd
+from academy_tutorial.player import BattleshipPlayer
+
+EXCHANGE_ADDRESS = 'https://exchange.academy-agents.org'
+logger = logging.getLogger(__name__)
+
+
+class MyBattleshipPlayer(BattleshipPlayer):
+    def __init__(
+        self,
+    ) -> None:
+        from academy_tutorial.battleship import Board  # noqa: PLC0415
+
+        super().__init__()
+        self.guesses = Board()
+
+    @action
+    async def get_move(self) -> Crd:
+        import random  # noqa: PLC0415
+
+        from academy_tutorial.battleship import Crd  # noqa: PLC0415
+
+        while True:
+            row = random.randint(0, self.guesses.size - 1)
+            col = random.randint(0, self.guesses.size - 1)
+            if self.guesses.receive_attack(Crd(row, col)) != 'guessed':
+                return Crd(row, col)
+
+    @action
+    async def notify_result(
+        self,
+        loc: Crd,
+        result: Literal['hit', 'miss', 'guessed'],
+    ) -> None:
+        # Naive player does not keep track of results
+        return
+
+    @action
+    async def notify_move(self, loc: Crd) -> None:
+        # Naive player does not keep track of where guesses
+        # happen
+        return
+
+    @action
+    async def new_game(self, ships: list[int], size: int = 10) -> Board:
+        from academy_tutorial.battleship import Board  # noqa: PLC0415
+        from academy_tutorial.battleship import Crd  # noqa: PLC0415
+
+        self.guesses = Board(size)
+        my_board = Board(size)
+        for i, ship in enumerate(ships):
+            my_board.place_ship(Crd(i, 0), ship, 'horizontal')
+        return my_board
+
+
+async def main() -> int:
+    init_logging(logging.INFO)
+    factory = HttpExchangeFactory(
+        EXCHANGE_ADDRESS,
+        auth_method='globus',
+    )
+    async with await Manager.from_exchange_factory(
+        factory=factory,
+    ) as manager:
+        console = await factory.console()
+        player = await manager.launch(MyBattleshipPlayer)
+        group_id = uuid.UUID('47697db5-c19f-11f0-981f-0ee9d7d7fffb')
+        await player.ping()
+
+        await console.share_mailbox(manager.user_id, group_id)
+        await console.share_mailbox(player.agent_id, group_id)
+
+        tournament_aid = AgentId(
+            uid=uuid.UUID('a6a33dd5-1892-4e48-a2fc-cd7c1ec5a82f'),
+        )
+        tournament = Handle(tournament_aid)
+        await tournament.register_player(player, 'dummy1')
+
+        await manager.wait((player,))
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
Adding script for people to share their agents with a group and enter the tournament. 
Use environment variables to communicate group and tournament.
Persist tournament mailbox and enable the re-use of the ID when re-launching the tournament.

**Currently this branch depends on a feature branch of academy until group support is merged into main.**